### PR TITLE
Allow to set LibRaw dataerror_handler.

### DIFF
--- a/rawpy/__init__.py
+++ b/rawpy/__init__.py
@@ -13,10 +13,18 @@ def imread(pathOrFile):
     :param str|file pathOrFile: path or file object of RAW image that will be read
     :rtype: :class:`rawpy.RawPy`
     """
+    global _callback_func
     d = RawPy()
+    if _callback_func is not None:
+        d.set_error_handler(_callback_func)
     if hasattr(pathOrFile, 'read'):
         d.open_buffer(pathOrFile)
     else:
         d.open_file(pathOrFile)
     d.unpack()
     return d
+
+_callback_func = None
+def set_error_callback(func):
+    global _callback_func
+    _callback_func = func


### PR DESCRIPTION
I ran into the situation where I needed to read a bunch of raw images for analysis in Python. With the help of RawPy, that is usually a piece of cake. It turned out that a couple of the files could not be read, resulting in LibRaw reporting a data corruption to stderr. However, that is the only way that the error is detectable. There are no exceptions, no error codes as return values, and the `raw_image` is still accessible, albeit corrupted.

LibRaw allows to set a callback function for handling such errors, and this pull request exposes corresponding methods to Python.