### PR TITLE
Expose camera-defined per-channel white level

### DIFF
--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -705,7 +705,6 @@ cdef class RawPy:
     property white_level:
         """
         Level at which the raw pixel value is considered to be saturated.
-        This value is calculated from the data for most cameras, and hardcoded for others.
         """
         def __get__(self):
             self.ensure_unpack()

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -711,7 +711,7 @@ cdef class RawPy:
             self.ensure_unpack()
             return self.p.imgdata.rawdata.color.maximum
 
-    property camera_white_lever_per_channel:
+    property camera_white_level_per_channel:
         """
         Per-channel linear data maximum read from file metadata.
         If RAW file does not contains this data, linear_max is set to zero.

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -720,7 +720,7 @@ cdef class RawPy:
         """
         def __get__(self):
             self.ensure_unpack()
-        return [self.p.imgdata.rawdata.color.linear_max[0],
+            return [self.p.imgdata.rawdata.color.linear_max[0],
                 self.p.imgdata.rawdata.color.linear_max[1],
                 self.p.imgdata.rawdata.color.linear_max[2],
                 self.p.imgdata.rawdata.color.linear_max[3]]

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -713,9 +713,7 @@ cdef class RawPy:
 
     property camera_white_level_per_channel:
         """
-        Per-channel linear data maximum read from file metadata.
-        If RAW file does not contains this data, values are set to zero.
-        Black value is not subtracted.
+        Per-channel saturation levels read from raw file metadata, if it exists. Otherwise None.
 
         :rtype: list of length 4
         """

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -714,7 +714,7 @@ cdef class RawPy:
     property camera_white_level_per_channel:
         """
         Per-channel linear data maximum read from file metadata.
-        If RAW file does not contains this data, linear_max is set to zero.
+        If RAW file does not contains this data, values are set to zero.
         Black value is not subtracted.
 
         :rtype: list of length 4

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -74,6 +74,7 @@ cdef extern from "libraw.h":
         unsigned    cblack[4102]
         unsigned    black
         unsigned    maximum
+        unsigned    linear_max[4]
         float       cmatrix[3][4]
         float       cam_xyz[4][3]
         void        *profile # a string?
@@ -708,6 +709,21 @@ cdef class RawPy:
         def __get__(self):
             self.ensure_unpack()
             return self.p.imgdata.rawdata.color.maximum
+
+    property linear_max:
+        """
+        Per-channel linear data maximum read from file metadata. 
+        If RAW file does not contains this data, linear_max is set to zero.
+        Black value is not subtracted.
+
+        :rtype: list of length 4
+        """
+        def __get__(self):
+            self.ensure_unpack()
+        return [self.p.imgdata.rawdata.color.linear_max[0],
+                self.p.imgdata.rawdata.color.linear_max[1],
+                self.p.imgdata.rawdata.color.linear_max[2],
+                self.p.imgdata.rawdata.color.linear_max[3]]
 
     property color_matrix:
         """

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -705,14 +705,15 @@ cdef class RawPy:
     property white_level:
         """
         Level at which the raw pixel value is considered to be saturated.
+        This value is calculated from the data for most cameras, and hardcoded for others.
         """
         def __get__(self):
             self.ensure_unpack()
             return self.p.imgdata.rawdata.color.maximum
 
-    property linear_max:
+    property camera_white_lever_per_channel:
         """
-        Per-channel linear data maximum read from file metadata. 
+        Per-channel linear data maximum read from file metadata.
         If RAW file does not contains this data, linear_max is set to zero.
         Black value is not subtracted.
 

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -718,10 +718,14 @@ cdef class RawPy:
         """
         def __get__(self):
             self.ensure_unpack()
-            return [self.p.imgdata.rawdata.color.linear_max[0],
+            levels = [self.p.imgdata.rawdata.color.linear_max[0],
                 self.p.imgdata.rawdata.color.linear_max[1],
                 self.p.imgdata.rawdata.color.linear_max[2],
                 self.p.imgdata.rawdata.color.linear_max[3]]
+            if all([l > 0 for l in levels]):
+                return levels
+            else:
+                return None
 
     property color_matrix:
         """


### PR DESCRIPTION
This PR exposes the `libraw_colordata_t::linear_max` vector as `RawPy.camera_white_level_per_channel`. This property might be useful for rectifying magenta highlights when demosaicking (see #100) by setting a custom saturation level. Following the [conversation with the author of LibRaw](https://www.libraw.org/comment/5980#comment-5980), we should be able to resolve the pink sky issue like so:
```python
with imread("/path/to/raw.CR2") as raw:
    # Compute the saturation level
    white_level = np.array(raw.camera_white_level_per_channel).min()
    saturation_level = raw.white_level if white_level == 0 else white_level
    # Demosaic
    rgb = raw.postprocess(
        no_auto_bright=True,
        user_sat=saturation_level,
        highlight_mode=HighlightMode.Clip,
    )
```