### PR TITLE
Python 3.9 support

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -10,9 +10,7 @@ source .github/scripts/retry.sh
 # List python versions
 ls /opt/python
 
-if [ $PYTHON_VERSION == "3.5" ]; then
-    PYBIN="/opt/python/cp35-cp35m/bin"
-elif [ $PYTHON_VERSION == "3.6" ]; then
+if [ $PYTHON_VERSION == "3.6" ]; then
     PYBIN="/opt/python/cp36-cp36m/bin"
 elif [ $PYTHON_VERSION == "3.7" ]; then
     PYBIN="/opt/python/cp37-cp37m/bin"

--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -18,6 +18,8 @@ elif [ $PYTHON_VERSION == "3.7" ]; then
     PYBIN="/opt/python/cp37-cp37m/bin"
 elif [ $PYTHON_VERSION == "3.8" ]; then
     PYBIN="/opt/python/cp38-cp38/bin"
+elif [ $PYTHON_VERSION == "3.9" ]; then
+    PYBIN="/opt/python/cp39-cp39/bin"
 else
     echo "Unsupported Python version $PYTHON_VERSION"
     exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # FIXME should be include:, but individual entries are not supported yet, so work-around
         config:
         - os-image: ubuntu-latest
           os-name: linux
           docker-image: quay.io/pypa/manylinux2010_x86_64
-          python-version: '3.5'
-          numpy-version: '1.9.*'
-        - os-image: ubuntu-latest
-          os-name: linux
-          docker-image: quay.io/pypa/manylinux2010_x86_64
           python-version: '3.6'
           numpy-version: '1.11.*'
         - os-image: ubuntu-latest
@@ -35,15 +29,10 @@ jobs:
           python-version: '3.9'
           numpy-version: '1.19.*'
 
-        - os-image: macos-latest
-          os-name: mac
-          # Ideally 10.6 (same as offical Python installer) but there
-          # are issues targeting that with newer XCode versions.
-          # As likely nobody is using 10.6 anymore, targeting 10.9 is acceptable.
-          # See https://github.com/pandas-dev/pandas/issues/23424#issuecomment-446393981.
-          macos-min-version: '10.9'
-          python-version: '3.5'
-          numpy-version: '1.9.*'
+        # Ideally 10.6 (same as offical Python installer) but there
+        # are issues targeting that with newer XCode versions.
+        # As likely nobody is using 10.6 anymore, targeting 10.9 is acceptable.
+        # See https://github.com/pandas-dev/pandas/issues/23424#issuecomment-446393981.
         - os-image: macos-latest
           os-name: mac
           macos-min-version: '10.9'
@@ -65,13 +54,8 @@ jobs:
           python-version: '3.9'
           numpy-version: '1.19.*'
 
-        # Use 2016 image for 3.5 as 2019 does not have VC++ 14.0 compiler.
+        # Use 2016 image as 2019 does not have VC++ 14.0 compiler.
         # https://github.community/t5/GitHub-Actions/Microsoft-Visual-C-14-0-compiler-not-available-on-Windows-2019/m-p/32871 
-        - os-image: windows-2016
-          os-name: windows
-          python-version: '3.5'
-          python-arch: '64'
-          numpy-version: '1.9'
         - os-image: windows-2016
           os-name: windows
           python-version: '3.6'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
           docker-image: quay.io/pypa/manylinux2010_x86_64
           python-version: '3.8'
           numpy-version: '1.17.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2010_x86_64
+          python-version: '3.9'
+          numpy-version: '1.19.*'
 
         - os-image: macos-latest
           os-name: mac
@@ -54,6 +59,11 @@ jobs:
           macos-min-version: '10.9'
           python-version: '3.8'
           numpy-version: '1.17.*'
+        - os-image: macos-latest
+          os-name: mac
+          macos-min-version: '10.9'
+          python-version: '3.9'
+          numpy-version: '1.19.*'
 
         # Use 2016 image for 3.5 as 2019 does not have VC++ 14.0 compiler.
         # https://github.community/t5/GitHub-Actions/Microsoft-Visual-C-14-0-compiler-not-available-on-Windows-2019/m-p/32871 
@@ -77,6 +87,11 @@ jobs:
           python-version: '3.8'
           python-arch: '64'
           numpy-version: '1.17'
+        - os-image: windows-2016
+          os-name: windows
+          python-version: '3.9'
+          python-arch: '64'
+          numpy-version: '1.19'
 
     runs-on: ${{ matrix.config.os-image }}
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ rawpy depends on NumPy. The minimum supported NumPy version depends on your Pyth
 | 3.6    | >= 1.11  |
 | 3.7    | >= 1.14  |
 | 3.8    | >= 1.17  |
+| 3.9    | >= 1.19  |
 
 
 [libraw]: https://www.libraw.org

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ rawpy depends on NumPy. The minimum supported NumPy version depends on your Pyth
 
 | Python | NumPy    |
 | ------ | -------- |
-| 3.5    | >= 1.9   |
 | 3.6    | >= 1.11  |
 | 3.7    | >= 1.14  |
 | 3.8    | >= 1.17  |


### PR DESCRIPTION
Also dropping Python 3.5 as it went EOL.

Not all dependencies have caught up with Python 3.9 yet, so CI will fail for now. Once CI is green, this PR can be merged and a new rawpy version released.