### PR TITLE
Do not compile LibRaw for mingw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ from Cython.Build import cythonize
 #       See https://github.com/letmaik/rawpy/issues/72.
 buildGPLCode = os.getenv('RAWPY_BUILD_GPL_CODE') == '1'
 
-isWindows = os.name == 'nt'
+# don't treat mingw as Windows (https://stackoverflow.com/a/51200002)
+isWindows = os.name == 'nt' and 'GCC' not in sys.version
 isMac = sys.platform == 'darwin'
 is64Bit = sys.maxsize > 2**32
 


### PR DESCRIPTION
Platform detection based on https://stackoverflow.com/a/51200002

Official CPython and Anaconda packages are built w/ MSVC.