### PR TITLE
Use PyArray_SetBaseObject as ndarray.base is readonly property

### DIFF
--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -506,7 +506,7 @@ cdef class RawPy:
             # ndarr must hold a reference to this object,
             # otherwise the underlying data gets lost when the RawPy instance gets out of scope
             # (which would trigger __dealloc__)
-            ndarr.base = <PyObject*> self
+            np.PyArray_SetBaseObject(ndarr, self)
             # Python doesn't know about above assignment as it's in C-level 
             Py_INCREF(self)
             return ndarr
@@ -1188,7 +1188,7 @@ cdef class processed_image_wrapper:
         ndarr = np.PyArray_SimpleNewFromData(3, shape, 
                                              np.NPY_UINT8 if self.processed_image.bits == 8 else np.NPY_UINT16,
                                              self.processed_image.data)
-        ndarr.base = <PyObject*> self
+        np.PyArray_SetBaseObject(ndarr, self)
         # Python doesn't know about above assignment as it's in C-level 
         Py_INCREF(self)
         return ndarr

--- a/rawpy/enhance.py
+++ b/rawpy/enhance.py
@@ -162,7 +162,7 @@ def _find_bad_pixel_candidates_bayer2x2(raw, isCandidateFn):
         median_ = partial(cv2.medianBlur, ksize=r)
     else:
         kernel = np.ones((r,r))
-        median_ = partial(median, selem=kernel)
+        median_ = partial(median, footprint=kernel)
         
     coords = []
     
@@ -265,7 +265,7 @@ def _repair_bad_pixels_bayer2x2(raw, coords, method='median'):
         median_ = partial(cv2.medianBlur, ksize=r)
     else:
         kernel = np.ones((r,r))
-        median_ = partial(median, selem=kernel)
+        median_ = partial(median, footprint=kernel)
             
     # we have 4 colors (two greens are always seen as two colors)
     for offset_y in [0,1]:


### PR DESCRIPTION
### Change 1

Numpy 1.7 introduced the `PyArray_SetBaseObject` method of setting `ndarray.base` property as in recent versions `base` has become a read-only. 

When compiling `rawpy` with a recent version of numpy (1.23.2) we get the following errors:
```
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
                  raise RuntimeError('unsupported raw data')

              # ndarr must hold a reference to this object,
              # otherwise the underlying data gets lost when the RawPy instance gets out of scope
              # (which would trigger __dealloc__)
              ndarr.base = <PyObject*> self
                   ^
  ------------------------------------------------------------

  rawpy/_rawpy.pyx:509:17: Assignment to a read-only property

  Error compiling Cython file:
  ------------------------------------------------------------
  ...
          shape[2] = <np.npy_intp> self.processed_image.colors
          cdef np.ndarray ndarr
          ndarr = np.PyArray_SimpleNewFromData(3, shape,
                                               np.NPY_UINT8 if self.processed_image.bits == 8 else np.NPY_UINT16,
                                               self.processed_image.data)
          ndarr.base = <PyObject*> self
               ^
  ------------------------------------------------------------

  rawpy/_rawpy.pyx:1191:13: Assignment to a read-only property
```

Using numpy's `PyArray_SetBaseObject` fixes this (per: https://github.com/cython/cython/issues/3690#issuecomment-645665793)

_Breaking out from this thread: https://github.com/letmaik/rawpy/issues/171#issuecomment-1522950983_

### Change 2

Additionally the signature for `skimage.filters.rank.median` has changed, `selem` has changed to `footprint` so have updated that as well.
