### PR TITLE
Allow explicit use of system libraw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import sys
 import zipfile
-import re
 import glob
 from urllib.request import urlretrieve
 
@@ -21,6 +20,7 @@ from Cython.Build import cythonize
 # Note: Building GPL demosaic packs only works with libraw <= 0.18.
 #       See https://github.com/letmaik/rawpy/issues/72.
 buildGPLCode = os.getenv('RAWPY_BUILD_GPL_CODE') == '1'
+useSystemLibraw = os.getenv('RAWPY_USE_SYSTEM_LIBRAW') == '1'
 
 # don't treat mingw as Windows (https://stackoverflow.com/a/51200002)
 isWindows = os.name == 'nt' and 'GCC' not in sys.version
@@ -81,7 +81,7 @@ def use_pkg_config():
 # on a configure script, or cmake or other build infrastructure. 
 # A possible work-around could be to statically link against libraw.
 
-if isWindows or isMac:
+if (isWindows or isMac) and not useSystemLibraw:
     external_dir = os.path.abspath('external')
     libraw_dir = os.path.join(external_dir, 'LibRaw')
     cmake_build = os.path.join(external_dir, 'LibRaw-cmake', 'build')
@@ -251,7 +251,7 @@ package_data = {}
 # evil hack, check cmd line for relevant commands
 # custom cmdclasses didn't work out in this case
 cmdline = ''.join(sys.argv[1:])
-needsCompile = any(s in cmdline for s in ['install', 'bdist', 'build_ext'])
+needsCompile = any(s in cmdline for s in ['install', 'bdist', 'build_ext']) and not useSystemLibraw
 if isWindows and needsCompile:
     windows_libraw_compile()        
     package_data['rawpy'] = ['*.dll']


### PR DESCRIPTION
I made this modification locally to support using the system libraw on macOS, which I installed via Homebrew.

At the time builds on macOS arm64 were breaking (still no wheels available), and this was a quick way for me to get the package installed. I prefer using a shared library anyway, but that might just be me.

Presented here with minimal changes. If you want it let me know what else is required