### PR TITLE
#231: Precise `numpy` required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -308,5 +308,5 @@ setup(
       packages = find_packages(),
       ext_modules = extensions,
       package_data = package_data,
-      install_requires=['numpy']
+      install_requires=['numpy <= 1.26.4']
 )


### PR DESCRIPTION
Note that I have not (yet) tested this change.

The aim of this change is to prevent incorrect configuration until rawpy compatibility with numpy 2.0.0 is brought.

Related to https://codeberg.org/Benjamin_Loison/rawpy/issues/4.