### PR TITLE
Handle corrupt files

### DIFF
--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -955,6 +955,7 @@ cdef class RawPy:
             else:
                 raise LibRawNonFatalError(errstr)
 
+        cdef int error_count
         with nogil:
             error_count = self.p.error_count()
         if error_count > 0:

--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -201,6 +201,7 @@ IF UNAME_SYSNAME == "Windows":
             int unpack() nogil
             int unpack_thumb() nogil
             int COLOR(int row, int col) nogil
+            int error_count() nogil
             int dcraw_process() nogil
             libraw_processed_image_t* dcraw_make_mem_image(int *errcode) nogil
             libraw_processed_image_t* dcraw_make_mem_thumb(int *errcode) nogil
@@ -218,6 +219,7 @@ ELSE:
             int unpack() nogil
             int unpack_thumb() nogil
             int COLOR(int row, int col)
+            int error_count() nogil
             int dcraw_process() nogil
             libraw_processed_image_t* dcraw_make_mem_image(int *errcode) nogil
             libraw_processed_image_t* dcraw_make_mem_thumb(int *errcode) nogil
@@ -952,6 +954,11 @@ cdef class RawPy:
                 raise LibRawFatalError(errstr)
             else:
                 raise LibRawNonFatalError(errstr)
+
+        with nogil:
+            error_count = self.p.error_count()
+        if error_count > 0:
+            raise LibRawDataError("Data error or unsupported file format")
 
 class DemosaicAlgorithm(Enum):
     """

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -35,6 +35,9 @@ raw5TestPath = os.path.join(thisDir, 'RAW_CANON_40D_SRAW_V103.CR2')
 # Kodak DC50 with special characters in filename
 raw6TestPath = os.path.join(thisDir, 'RAW_KODAK_DC50_é.KDC')
 
+# CR2 file with corrupted data
+raw7TestPath = os.path.join(thisDir, 'M0054341_01_00005.cr2')
+
 def testVersion():
     print('using libraw', rawpy.libraw_version)
     pprint(rawpy.flags)
@@ -267,7 +270,14 @@ def testLibRawOutOfOrderCallError():
     with pytest.raises(rawpy.LibRawOutOfOrderCallError):
         raw = rawpy.RawPy()
         raw.unpack()
-    
+
+def testCorruptFile():
+    im = rawpy.imread(raw7TestPath)
+    with pytest.raises(rawpy.LibRawDataError):
+        im.postprocess()
+    with pytest.raises(rawpy.LibRawDataError):
+        im.extract_thumb()
+
 def save(path, im):
     # both imageio and skimage currently save uint16 images with 180deg rotation
     # as they both use freeimage and this has some weird internal formats
@@ -289,4 +299,4 @@ if __name__ == '__main__':
     #testFileOpenAndPostProcess()
     #testBadPixelRepair()
     testFindBadPixelsNikonD4()
-    
+    testCorruptFile()


### PR DESCRIPTION
Previously, #76 attempted to handle corruption by setting up a libraw `dataerror_handler`.  #229 refined #76 but there are segfaults.

This PR handles corruption in a different way: We ask libraw how many data errors occurred when reading the file and raise an exception if there were more than zero.  The test data from #229 was particularly useful in verifying that the method works.

Fixes #228.