### PR TITLE
Bump setup-python to v5, setup-qemu-action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
 
     - name: Set up QEMU
       if: matrix.config.python-arch == 'aarch64'
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
 
     - name: Build wheels (Linux)
       if: matrix.config.os-name == 'linux'
@@ -188,7 +188,7 @@ jobs:
 
     - name: Setup Python (Windows)
       if: matrix.config.os-name == 'windows'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -353,7 +353,7 @@ jobs:
 
     - name: Set up QEMU
       if: matrix.config.python-arch == 'aarch64'
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
 
     - name: Test wheel (Linux)
       if: matrix.config.os-name == 'linux'
@@ -364,7 +364,7 @@ jobs:
 
     - name: Setup Python (Windows)
       if: matrix.config.os-name == 'windows'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -378,7 +378,7 @@ jobs:
 
     - name: Setup Python (macOS)
       if: matrix.config.os-name == 'mac'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config.python-version }}
 
@@ -398,7 +398,7 @@ jobs:
     - uses: actions/checkout@v4
    
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
@@ -438,7 +438,7 @@ jobs:
         path: dist
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
     
     - name: Upload wheels to PyPI
       run: |


### PR DESCRIPTION
This PR upgrades:
* `actions/setup-python` from v4 to v5
* `docker/setup-qemu-action` from v1 to v3

This takes care of CI warnings:

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-python@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
```
The following actions uses node12 which is deprecated and will be forced to run on node16: docker/setup-qemu-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```