### PR TITLE
Relax minimum numpy version to 1.26.0

### DIFF
--- a/.github/scripts/test-linux.sh
+++ b/.github/scripts/test-linux.sh
@@ -22,8 +22,7 @@ PYVER=${PYTHON_VERSION//.}
 
 # Install package and test
 ${PYBIN}/pip install ./dist/rawpy*cp${PYVER}*manylinux*${PYTHON_ARCH}*.whl
-
-${PYBIN}/pip install -r dev-requirements.txt
+${PYBIN}/pip install -r dev-requirements.txt "numpy==${NUMPY_VERSION}"
 
 mkdir tmp_for_test
 pushd tmp_for_test

--- a/.github/scripts/test-macos.sh
+++ b/.github/scripts/test-macos.sh
@@ -11,7 +11,7 @@ source env/$VENV/bin/activate
 pip install dist/rawpy*cp${PYVER}*macosx*${PYTHON_ARCH}*.whl
 
 # Test installed rawpy
-pip install -r dev-requirements.txt
+pip install -r dev-requirements.txt "numpy==${NUMPY_VERSION}"
 mkdir tmp_for_test
 pushd tmp_for_test
 python -u -m pytest -v -s ../test

--- a/.github/scripts/test-windows.ps1
+++ b/.github/scripts/test-windows.ps1
@@ -65,6 +65,9 @@ if (!$env:PYTHON_VERSION) {
 if ($env:PYTHON_ARCH -ne 'x86' -and $env:PYTHON_ARCH -ne 'x86_64') {
     throw "PYTHON_ARCH env var must be x86 or x86_64"
 }
+if (!$env:NUMPY_VERSION) {
+    throw "NUMPY_VERSION env var missing"
+}
 
 $PYVER = ($env:PYTHON_VERSION).Replace('.', '')
 
@@ -90,7 +93,7 @@ Exit-VEnv
 Create-And-Enter-VEnv testsuite
 python -m pip uninstall -y rawpy
 ls dist\*cp${PYVER}*win*.whl | % { exec { python -m pip install $_ } }
-exec { python -m pip install -r dev-requirements.txt }
+exec { python -m pip install -r dev-requirements.txt numpy==$env:NUMPY_VERSION }
 
 # Avoid using in-source package during tests
 mkdir -f tmp_for_test | out-null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_x86_64
+          python-arch: 'x86_64'
+          python-version: '3.12'
+          numpy-version: '1.26.4'
 
         - os-image: ubuntu-latest
           os-name: linux
@@ -263,6 +269,12 @@ jobs:
           python-arch: 'aarch64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.12'
+          numpy-version: '1.26.4'
 
         - os-image: macos-12
           os-name: mac
@@ -288,6 +300,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: macos-12
+          os-name: mac
+          macos-min-version: '10.9'
+          python-arch: 'x86_64'
+          python-version: '3.12'
+          numpy-version: '1.26.4'
 
         - os-image: macos-14 # M1
           os-name: mac
@@ -313,6 +331,12 @@ jobs:
           python-arch: 'arm64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: macos-14 # M1
+          os-name: mac
+          macos-min-version: '11.0'
+          python-arch: 'arm64'
+          python-version: '3.12'
+          numpy-version: '1.26.4'
 
         - os-image: windows-2019
           os-name: windows
@@ -334,6 +358,11 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: windows-2019
+          os-name: windows
+          python-arch: 'x86_64'
+          python-version: '3.12'
+          numpy-version: '1.26.4'
 
     runs-on: ${{ matrix.config.os-image }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,7 @@ jobs:
       env:
         PYTHON_ARCH: ${{ matrix.config.python-arch }}
         PYTHON_VERSION: ${{ matrix.config.python-version }}
+        NUMPY_VERSION: ${{ matrix.config.numpy-version }}
 
     - name: Setup Python (Windows)
       if: matrix.config.os-name == 'windows'
@@ -404,6 +405,7 @@ jobs:
       env:
         PYTHON_VERSION: ${{ matrix.config.python-version }}
         PYTHON_ARCH: ${{ matrix.config.python-arch }}
+        NUMPY_VERSION: ${{ matrix.config.numpy-version }}
 
     - name: Setup Python (macOS)
       if: matrix.config.os-name == 'mac'
@@ -417,6 +419,7 @@ jobs:
       env:
         PYTHON_ARCH: ${{ matrix.config.python-arch }}
         PYTHON_VERSION: ${{ matrix.config.python-version }}
+        NUMPY_VERSION: ${{ matrix.config.numpy-version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -312,5 +312,5 @@ setup(
       packages = find_packages(),
       ext_modules = extensions,
       package_data = package_data,
-      install_requires=['numpy >= 2.0']
+      install_requires=['numpy >= 1.26.0']
 )


### PR DESCRIPTION
Numpy 2.0 was released back in June - a big milestone!  Since it's so recent, a lot of packages haven't yet been able to upgrade to Numpy 2.0, so 1.x continued support will be important for facilitating continued compatibility with other packages.

This PR follows [numpy's guidance for building wheels that work on both 2.0 and 1.xx releases](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice):

> When you build wheels for your package using a NumPy 2.x version at build time, those **will work** with NumPy 1.xx.

We already use NumPy 2.x at build time, so that's easy.  This PR relaxes the install requirement to `numpy>=1.26.0` and adds one CI job per operating system to verify that rawpy does continue to work with NumPy 1.x.