### PR TITLE
Add support for building Python 3.13 wheels, and bump MacOS version

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -18,6 +18,8 @@ elif [ $PYTHON_VERSION == "3.11" ]; then
     PYBIN="/opt/python/cp311-cp311/bin"
 elif [ $PYTHON_VERSION == "3.12" ]; then
     PYBIN="/opt/python/cp312-cp312/bin"
+elif [ $PYTHON_VERSION == "3.13" ]; then
+    PYBIN="/opt/python/cp313-cp313/bin"
 else
     echo "Unsupported Python version $PYTHON_VERSION"
     exit 1

--- a/.github/scripts/test-linux.sh
+++ b/.github/scripts/test-linux.sh
@@ -14,6 +14,8 @@ elif [ $PYTHON_VERSION == "3.11" ]; then
     PYBIN="/opt/python/cp311-cp311/bin"
 elif [ $PYTHON_VERSION == "3.12" ]; then
     PYBIN="/opt/python/cp312-cp312/bin"
+elif [ $PYTHON_VERSION == "3.13" ]; then
+    PYBIN="/opt/python/cp313-cp313/bin"
 else
     echo "Unsupported Python version $PYTHON_VERSION"
     exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,31 +99,31 @@ jobs:
           python-version: '3.13'
           numpy-version: '2.1.*'
 
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.9'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.10'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.11'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
@@ -317,37 +317,37 @@ jobs:
           python-version: '3.13'
           numpy-version: '2.1.*'
 
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.9'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.10'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.11'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '1.26.4'
-        - os-image: macos-12
+        - os-image: macos-13
           os-name: mac
           macos-min-version: '10.9'
           python-arch: 'x86_64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_x86_64
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: ubuntu-latest
           os-name: linux
@@ -86,6 +92,12 @@ jobs:
           python-arch: 'aarch64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: macos-12
           os-name: mac
@@ -111,6 +123,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: macos-12
+          os-name: mac
+          macos-min-version: '10.9'
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: macos-14 # M1
           os-name: mac
@@ -136,6 +154,12 @@ jobs:
           python-arch: 'arm64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: macos-14 # M1
+          os-name: mac
+          macos-min-version: '11.0'
+          python-arch: 'arm64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: windows-2019
           os-name: windows
@@ -157,6 +181,11 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '2.0.*'
+        - os-image: windows-2019
+          os-name: windows
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
     runs-on: ${{ matrix.config.os-image }}
 
@@ -244,6 +273,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '1.26.4'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_x86_64
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: ubuntu-latest
           os-name: linux
@@ -275,6 +310,12 @@ jobs:
           python-arch: 'aarch64'
           python-version: '3.12'
           numpy-version: '1.26.4'
+        - os-image: ubuntu-latest
+          os-name: linux
+          docker-image: quay.io/pypa/manylinux2014_aarch64
+          python-arch: 'aarch64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: macos-12
           os-name: mac
@@ -306,6 +347,12 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '1.26.4'
+        - os-image: macos-12
+          os-name: mac
+          macos-min-version: '10.9'
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: macos-14 # M1
           os-name: mac
@@ -337,6 +384,12 @@ jobs:
           python-arch: 'arm64'
           python-version: '3.12'
           numpy-version: '1.26.4'
+        - os-image: macos-14 # M1
+          os-name: mac
+          macos-min-version: '11.0'
+          python-arch: 'arm64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
         - os-image: windows-2019
           os-name: windows
@@ -363,6 +416,11 @@ jobs:
           python-arch: 'x86_64'
           python-version: '3.12'
           numpy-version: '1.26.4'
+        - os-image: windows-2019
+          os-name: windows
+          python-arch: 'x86_64'
+          python-version: '3.13'
+          numpy-version: '2.1.*'
 
     runs-on: ${{ matrix.config.os-image }}
 
@@ -428,7 +486,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-   
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
@@ -471,7 +529,7 @@ jobs:
 
     - name: Setup Python
       uses: actions/setup-python@v5
-    
+
     - name: Upload wheels to PyPI
       run: |
         pip install twine


### PR DESCRIPTION
Added new tasks to the build matrix to support building Python 3.13 wheels. 

Currently, building the wheel is successful in Github Actions, but running the tests fails ([See run on my branch here](https://github.com/marsfan/rawpy/actions/runs/11831177257)). I've identified that the source of the failures is not due to any issues actually failing with the unit tests, but actually is due to the fact that `scikit-image` does not yet have release builds that support Python 3.13 (See https://github.com/scikit-image/scikit-image/issues/7596). When I install the pre-release builds for `scikit-image` on my computer, and run unit tests manually, the unit tests all pass.

Until `scikit-image` has an official release of 0.25, which will add Python 3.13 support, I'm going to leave this pull request in a draft state. Once there is an official release, I will change that. 


_Note: I have made no effort to add free-threading support to this module. [There's a guide here](https://py-free-threading.github.io/porting/#__tabbed_1_3) that may be useful._