### PR TITLE
Expose crop dimensions

### DIFF
--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -20,6 +20,9 @@ import sys
 import warnings
 from enum import Enum
 
+cdef extern from "limits.h":
+    cdef unsigned short USHRT_MAX
+
 cdef extern from "Python.h":
     wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *)
 
@@ -61,6 +64,10 @@ cdef extern from "libraw.h":
         LIBRAW_IMAGE_JPEG
         LIBRAW_IMAGE_BITMAP
     
+    ctypedef struct libraw_raw_inset_crop_t:
+        ushort cleft, ctop
+        ushort cwidth, cheight
+    
     ctypedef struct libraw_image_sizes_t:
         ushort raw_height, raw_width
         ushort height, width
@@ -68,6 +75,7 @@ cdef extern from "libraw.h":
         ushort iheight, iwidth
         double pixel_aspect
         int flip
+        libraw_raw_inset_crop_t[2] raw_inset_crops
         
     ctypedef struct libraw_colordata_t:
         float       cam_mul[4] 
@@ -249,7 +257,9 @@ ImageSizes = namedtuple('ImageSizes', ['raw_height', 'raw_width',
                                        'height', 'width', 
                                        'top_margin', 'left_margin',
                                        'iheight', 'iwidth',
-                                       'pixel_aspect', 'flip'])
+                                       'pixel_aspect', 'flip',
+                                       'crop_left_margin', 'crop_top_margin', 'crop_width', 'crop_height'
+                                       ])
 
 class RawType(Enum):
     """
@@ -568,11 +578,19 @@ cdef class RawPy:
         def __get__(self):
             self.ensure_unpack()
             cdef libraw_image_sizes_t* s = &self.p.imgdata.sizes
+
+            # LibRaw returns 65535 for cleft and ctop in some files - probably those that do not specify them
+            cdef bint has_cleft = s.raw_inset_crops[0].cleft != USHRT_MAX
+            cdef bint has_ctop = s.raw_inset_crops[0].ctop != USHRT_MAX
+
             return ImageSizes(raw_height=s.raw_height, raw_width=s.raw_width,
                               height=s.height, width=s.width,
                               top_margin=s.top_margin, left_margin=s.left_margin,
                               iheight=s.iheight, iwidth=s.iwidth,
-                              pixel_aspect=s.pixel_aspect, flip=s.flip)
+                              pixel_aspect=s.pixel_aspect, flip=s.flip,
+                              crop_left_margin=s.raw_inset_crops[0].cleft if has_cleft else 0,
+                              crop_top_margin=s.raw_inset_crops[0].ctop if has_ctop else 0,
+                              crop_width=s.raw_inset_crops[0].cwidth, crop_height=s.raw_inset_crops[0].cheight)
     
     property num_colors:
         """

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -228,6 +228,38 @@ def testVisibleSize():
         assert_equal(h, s.height)
         assert_equal(w, s.width)
         
+def testCropSizeNikon():
+    with rawpy.imread(rawTestPath) as raw:
+        s = raw.sizes
+        assert_equal(s.crop_left_margin, 0)
+        assert_equal(s.crop_top_margin, 0)
+        assert_equal(s.crop_width, 0)
+        assert_equal(s.crop_height, 0)
+
+def testCropSizeCanon():
+    with rawpy.imread(raw3TestPath) as raw:
+        s = raw.sizes
+        assert_equal(s.crop_left_margin, 168)
+        assert_equal(s.crop_top_margin, 56)
+        assert_equal(s.crop_width, 5616)
+        assert_equal(s.crop_height, 3744)
+
+def testCropSizeSigma():
+    with rawpy.imread(raw4TestPath) as raw:
+        s = raw.sizes
+        assert_equal(s.crop_left_margin, 0)
+        assert_equal(s.crop_top_margin, 0)
+        assert_equal(s.crop_width, 0)
+        assert_equal(s.crop_height, 0)
+
+def testCropSizeKodak():
+    with rawpy.imread(raw6TestPath) as raw:
+        s = raw.sizes
+        assert_equal(s.crop_left_margin, 0)
+        assert_equal(s.crop_top_margin, 0)
+        assert_equal(s.crop_width, 0)
+        assert_equal(s.crop_height, 0)
+
 def testHalfSizeParameter():
     raw = rawpy.imread(rawTestPath)
     s = raw.sizes


### PR DESCRIPTION
Hello, this is my attempt at exposing cropped dimensions, aiming to solve #139.

`ImageSizes` gets new fields: `crop_left_margin, crop_top_margin, crop_width, crop_height` matching LibRaw's [`raw_inset_crops`](https://www.libraw.org/docs/API-datastruct-eng.html#libraw_image_sizes_t).

In Canon CR2s this corresponds to the intended image resolution. E.g. 5616x3744 in RAW_CANON_5DMARK2_PREPROD.CR2, vs 5634x3752 which is in the `width, height` fields:

```python
ImageSizes(
    raw_height=3804, raw_width=5792, 
    height=3752, width=5634, 
    top_margin=52, left_margin=158, 
    iheight=3752, iwidth=5634, 
    pixel_aspect=1.0, flip=0, 
    crop_left_margin=168, crop_top_margin=56, 
    crop_width=5616, crop_height=3744)
```

Exiftool and exiv2 report 5616x3744 too.

In case of the test RAW files from Nikon, Sigma, Kodak all new fields are set to 0.