### PR TITLE
Remove unnecessary ensure_unpack calls

### DIFF
--- a/rawpy/_rawpy.pyx
+++ b/rawpy/_rawpy.pyx
@@ -576,7 +576,6 @@ cdef class RawPy:
         the RAW image and postprocessed image.        
         """
         def __get__(self):
-            self.ensure_unpack()
             cdef libraw_image_sizes_t* s = &self.p.imgdata.sizes
 
             # LibRaw returns 65535 for cleft and ctop in some files - probably those that do not specify them
@@ -599,7 +598,6 @@ cdef class RawPy:
         as some use two different greens. 
         """
         def __get__(self):
-            self.ensure_unpack()
             return self.p.imgdata.idata.colors
     
     property color_desc:
@@ -609,7 +607,6 @@ cdef class RawPy:
         There are cameras with two different greens for example.
         """
         def __get__(self):
-            self.ensure_unpack()
             return self.p.imgdata.idata.cdesc
     
     cpdef int raw_color(self, int row, int column):
@@ -650,7 +647,6 @@ cdef class RawPy:
         :rtype: ndarray of shape (hv,wv)
         """
         def __get__(self):
-            self.ensure_unpack()
             s = self.sizes
             return self.raw_colors[s.top_margin:s.top_margin+s.height,
                                    s.left_margin:s.left_margin+s.width]


### PR DESCRIPTION
Closes #253 

I've tested this by running:

```python
import rawpy

with rawpy.imread("iss030e122639.NEF") as f:
	print(f.sizes)
	print(f.num_colors)
	print(f.color_desc)
	print(f.raw_colors_visible)
```

And verifying that outputs match between this branch and main.

Now, `raw_colors_visible` accesses `raw_colors`, which still calls `ensure_unpack`.  To get a better benchmark, one can do:

```python
import rawpy

with rawpy.imread("iss030e122639.NEF") as f:
	print(f.sizes)
	print(f.num_colors)
	print(f.color_desc)
```

```bash
[pt:~/Documents/rawpy/test] [venv] unpackopt+* ± hyperfine 'python test.py'
Benchmark 1: python test.py
  Time (mean ± σ):     106.9 ms ±  19.7 ms    [User: 521.1 ms, System: 144.5 ms]
  Range (min … max):    92.2 ms … 175.6 ms    16 runs
```

vs. main branch:

```bash
[pt:~/Documents/rawpy/test] [venv] main+* 4s ± hyperfine 'python test.py'
Benchmark 1: python test.py
  Time (mean ± σ):     345.6 ms ±  12.3 ms    [User: 1732.8 ms, System: 491.4 ms]
  Range (min … max):   319.7 ms … 359.2 ms    10 runs
```