### PR TITLE
Add test for opening non existent file

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -310,6 +310,11 @@ def testCorruptFile():
     with pytest.raises(rawpy.LibRawDataError):
         im.extract_thumb()
 
+def testOpenNonExistentFile():
+    with pytest.raises(rawpy.LibRawIOError):
+        with rawpy.open("nonexistent.nef") as f:
+            pass
+
 def print_stats(rgb):
     print(rgb.dtype, 
           np.min(rgb, axis=(0,1)), np.max(rgb, axis=(0,1)), # range for each channel


### PR DESCRIPTION
Adds a test for making sure that opening a non-existent file throws a `LibRawIOError` exception (and not `LibRawTooBigError`) as reported in #210. It does not fix the underlying cause.