### PR TITLE
Modernize build system with pyproject.toml and setup.py refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.so.*
 
 # Distribution / packaging
 .Python
@@ -74,3 +75,6 @@ Miniconda*.exe
 /vcpkg
 
 !/logo/logo.png
+.venv/
+.venv-test/
+tmp/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,31 @@
-include README.rst
+# Include documentation and license files
+include README.md
+include LICENSE
+include LICENSE.LibRaw
+# Note: AGENTS.md is excluded - it's for development only, not end users
+
+# Include Cython source and helper headers
+include rawpy/_rawpy.pyx
 include rawpy/def_helper.h
+include rawpy/data_helper.h
+
+# Include type stub and marker
+include rawpy/py.typed
+include rawpy/_rawpy.pyi
+
+# Include external LibRaw source code (required for building from source)
+recursive-include external/LibRaw *.h *.cpp
+include external/LibRaw/COPYRIGHT
+include external/LibRaw/LICENSE.CDDL
+include external/LibRaw/LICENSE.LGPL
+include external/LibRaw/Changelog.txt
+recursive-include external/LibRaw-cmake *.cmake *.cmake.in CMakeLists.txt
+
+# Exclude build artifacts
+prune external/LibRaw-cmake/build
+
+# Exclude development-only directories
+prune test
+
+# Exclude generated files (regenerated from .pyx during build)
+exclude rawpy/_rawpy.cpp

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,7 @@
 # build dependencies
 wheel>=0.31.0
+setuptools>=69
+build
 delocate;sys.platform == 'darwin'
 cython
 
@@ -12,7 +14,7 @@ scikit-image
 # test dependencies
 pytest
 imageio>=2.21  # for imageio.v3 / iio support
-setuptools
+mypy
 
 # documentation dependencies
 sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = [
+    "setuptools>=69.0.0",
+    "wheel",
+    "Cython>=0.29.32",
+    "cmake",
+    # Build against NumPy 2.x headers. Extensions compiled with NumPy 2.0+
+    # are backward-compatible with NumPy >= 1.19 at runtime.
+    "numpy>=2.0.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rawpy"
+dynamic = ["version"]
+description = "RAW image processing for Python, a wrapper for libraw"
+readme = "README.md"
+authors = [
+  {name = "Maik Riechert"}
+]
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: Cython",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "numpy>=1.26.0"
+]
+
+[project.urls]
+Homepage = "https://github.com/letmaik/rawpy"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "imageio>=2.21",
+    "mypy",
+    "scikit-image",
+]
+
+[tool.setuptools.packages.find]
+include = ["rawpy*"]
+
+[tool.mypy]
+# Global mypy configuration for rawpy project
+warn_unused_configs = true
+check_untyped_defs = true
+
+# Selectively ignore missing imports for optional dependencies
+[[tool.mypy.overrides]]
+module = [
+    "skimage.*",
+    "cv2",
+    "scipy.*",
+    "imageio",
+    "imageio.*",
+    "imageio.v3"
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["test"]

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ def unix_libraw_compile():
             ]
         )
 
-    cmds = [" ".join(cmake_args), "cmake --build . --target install -j"]
+    cmds = [" ".join(cmake_args), "cmake --build . --target install"]
 
     for cmd in cmds:
         print(f"Running: {cmd}")


### PR DESCRIPTION
Enable proper sdist builds and build isolation with a new `pyproject.toml` (PEP 517/518). Unify Linux and macOS LibRaw compilation into a single `unix_libraw_compile()` code path. Rewrite `MANIFEST.in` so sdist packages include all required sources (LibRaw headers/sources, Cython `.pyx`, type stubs).